### PR TITLE
feat: implement note-taking library (#7)

### DIFF
--- a/notes/export.py
+++ b/notes/export.py
@@ -1,0 +1,21 @@
+from typing import Optional
+from notes.model import Note
+from notes.store import NoteStore
+
+
+def export_note(note: Note) -> str:
+    date_str = note.created_at.strftime("%Y-%m-%d %H:%M")
+    if note.tags:
+        meta = f"_Tags: {', '.join(note.tags)}_ | _Created: {date_str}_"
+    else:
+        meta = f"_Created: {date_str}_"
+
+    return f"# {note.title}\n\n{meta}\n\n{note.content}"
+
+
+def export_store(store: NoteStore, query: Optional[str] = None) -> str:
+    notes = store.search(query) if query else store.list()
+    if not notes:
+        return ""
+    sections = [export_note(n) for n in notes]
+    return "\n\n---\n\n".join(sections)

--- a/notes/model.py
+++ b/notes/model.py
@@ -1,0 +1,16 @@
+from dataclasses import dataclass, field
+from datetime import datetime
+from typing import List
+import uuid
+
+
+@dataclass
+class Note:
+    title: str
+    content: str
+    tags: List[str] = field(default_factory=list)
+    id: str = field(default_factory=lambda: str(uuid.uuid4()))
+    created_at: datetime = field(default_factory=datetime.now)
+
+    def __repr__(self) -> str:
+        return f"Note(id={self.id!r}, title={self.title!r})"

--- a/notes/model.py
+++ b/notes/model.py
@@ -14,3 +14,16 @@ class Note:
 
     def __repr__(self) -> str:
         return f"Note(id={self.id!r}, title={self.title!r})"
+
+    def add_tag(self, tag: str) -> None:
+        normalised = tag.strip().lower()
+        if normalised not in self.tags:
+            self.tags.append(normalised)
+
+    def remove_tag(self, tag: str) -> None:
+        normalised = tag.strip().lower()
+        if normalised in self.tags:
+            self.tags.remove(normalised)
+
+    def has_tag(self, tag: str) -> bool:
+        return tag.strip().lower() in self.tags

--- a/notes/store.py
+++ b/notes/store.py
@@ -6,6 +6,7 @@ from datetime import datetime
 
 
 class NoteStore:
+
     def __init__(self, path: str) -> None:
         self._path = path
         self._notes: Dict[str, Note] = {}
@@ -29,6 +30,26 @@ class NoteStore:
         del self._notes[id]
         self._save()
         return True
+
+    def search(self, query: str) -> List[Note]:
+        q = query.lower()
+        return [
+            n for n in self._notes.values()
+            if q in n.title.lower() or q in n.content.lower()
+        ]
+
+    def filter_by_tag(self, tag: str) -> List[Note]:
+        return [n for n in self._notes.values() if tag in n.tags]
+
+    def filter_by_date(
+        self,
+        since: datetime,
+        until: Optional[datetime] = None,
+    ) -> List[Note]:
+        results = [n for n in self._notes.values() if n.created_at >= since]
+        if until is not None:
+            results = [n for n in results if n.created_at <= until]
+        return results
 
     def _save(self) -> None:
         data = {

--- a/notes/store.py
+++ b/notes/store.py
@@ -1,0 +1,57 @@
+import json
+import os
+from typing import Dict, List, Optional
+from notes.model import Note
+from datetime import datetime
+
+
+class NoteStore:
+    def __init__(self, path: str) -> None:
+        self._path = path
+        self._notes: Dict[str, Note] = {}
+        if os.path.exists(path):
+            self._load()
+
+    def add(self, note: Note) -> Note:
+        self._notes[note.id] = note
+        self._save()
+        return note
+
+    def get(self, id: str) -> Optional[Note]:
+        return self._notes.get(id)
+
+    def list(self) -> List[Note]:
+        return list(self._notes.values())
+
+    def delete(self, id: str) -> bool:
+        if id not in self._notes:
+            return False
+        del self._notes[id]
+        self._save()
+        return True
+
+    def _save(self) -> None:
+        data = {
+            nid: {
+                "id": n.id,
+                "title": n.title,
+                "content": n.content,
+                "tags": n.tags,
+                "created_at": n.created_at.isoformat(),
+            }
+            for nid, n in self._notes.items()
+        }
+        with open(self._path, "w") as f:
+            json.dump(data, f)
+
+    def _load(self) -> None:
+        with open(self._path) as f:
+            data = json.load(f)
+        for nid, d in data.items():
+            self._notes[nid] = Note(
+                id=d["id"],
+                title=d["title"],
+                content=d["content"],
+                tags=d["tags"],
+                created_at=datetime.fromisoformat(d["created_at"]),
+            )

--- a/tests/test_export.py
+++ b/tests/test_export.py
@@ -1,0 +1,75 @@
+import tempfile
+from datetime import datetime
+from notes.model import Note
+from notes.store import NoteStore
+from notes.export import export_note, export_store
+
+
+def make_note(title="Test Note", content="Some content", tags=None):
+    return Note(
+        title=title,
+        content=content,
+        tags=tags or [],
+        created_at=datetime(2024, 3, 15, 10, 30),
+    )
+
+
+def test_export_note_contains_title_as_h1():
+    n = make_note(title="My Note")
+    md = export_note(n)
+    assert "# My Note" in md
+
+
+def test_export_note_contains_content():
+    n = make_note(content="Hello world")
+    md = export_note(n)
+    assert "Hello world" in md
+
+
+def test_export_note_contains_tags():
+    n = make_note(tags=["python", "tips"])
+    md = export_note(n)
+    assert "python" in md
+    assert "tips" in md
+
+
+def test_export_note_contains_date():
+    n = make_note()
+    md = export_note(n)
+    assert "2024-03-15" in md
+
+
+def test_export_note_no_tags_still_renders():
+    n = make_note(tags=[])
+    md = export_note(n)
+    assert "# " in md
+    assert n.content in md
+
+
+def test_export_store_contains_all_notes():
+    path = tempfile.mktemp(suffix=".json")
+    store = NoteStore(path)
+    store.add(make_note(title="Note A", content="aaa"))
+    store.add(make_note(title="Note B", content="bbb"))
+    md = export_store(store)
+    assert "Note A" in md
+    assert "Note B" in md
+
+
+def test_export_store_with_query_filters():
+    path = tempfile.mktemp(suffix=".json")
+    store = NoteStore(path)
+    store.add(make_note(title="Python tips", content="list comprehensions"))
+    store.add(make_note(title="Shopping", content="eggs and milk"))
+    md = export_store(store, query="Python")
+    assert "Python tips" in md
+    assert "Shopping" not in md
+
+
+def test_export_store_separates_notes():
+    path = tempfile.mktemp(suffix=".json")
+    store = NoteStore(path)
+    store.add(make_note(title="A"))
+    store.add(make_note(title="B"))
+    md = export_store(store)
+    assert "---" in md

--- a/tests/test_model.py
+++ b/tests/test_model.py
@@ -1,0 +1,46 @@
+from datetime import datetime
+import uuid
+from notes.model import Note
+
+
+def test_note_requires_only_title_and_content():
+    n = Note(title="Hello", content="World")
+    assert n.title == "Hello"
+    assert n.content == "World"
+
+
+def test_note_id_is_auto_generated():
+    n = Note(title="a", content="b")
+    assert isinstance(n.id, str)
+    uuid.UUID(n.id)  # raises if not a valid UUID
+
+
+def test_note_ids_are_unique():
+    a = Note(title="a", content="b")
+    b = Note(title="a", content="b")
+    assert a.id != b.id
+
+
+def test_note_created_at_is_auto_set():
+    before = datetime.now()
+    n = Note(title="t", content="c")
+    after = datetime.now()
+    assert isinstance(n.created_at, datetime)
+    assert before <= n.created_at <= after
+
+
+def test_note_tags_default_to_empty_list():
+    n = Note(title="t", content="c")
+    assert n.tags == []
+
+
+def test_note_tags_can_be_set():
+    n = Note(title="t", content="c", tags=["python", "notes"])
+    assert n.tags == ["python", "notes"]
+
+
+def test_note_repr_includes_title_and_id():
+    n = Note(title="My Note", content="content")
+    r = repr(n)
+    assert "My Note" in r
+    assert n.id in r

--- a/tests/test_search.py
+++ b/tests/test_search.py
@@ -1,0 +1,75 @@
+from datetime import datetime, timedelta
+import tempfile
+from notes.model import Note
+from notes.store import NoteStore
+
+
+def make_store_with_notes():
+    path = tempfile.mktemp(suffix=".json")
+    store = NoteStore(path)
+    store.add(Note(title="Python tips", content="Use list comprehensions"))
+    store.add(Note(title="Shopping list", content="Milk, eggs, PYTHON cake"))
+    store.add(Note(title="Meeting notes", content="Discuss project roadmap", tags=["work"]))
+    store.add(Note(title="Recipe", content="Bake at 350F", tags=["food", "cooking"]))
+    return store
+
+
+def test_search_matches_title():
+    store = make_store_with_notes()
+    results = store.search("Python")
+    titles = {n.title for n in results}
+    assert "Python tips" in titles
+
+
+def test_search_matches_content():
+    store = make_store_with_notes()
+    results = store.search("list comprehensions")
+    assert any("Python tips" in n.title for n in results)
+
+
+def test_search_is_case_insensitive():
+    store = make_store_with_notes()
+    results = store.search("python")
+    assert len(results) >= 2  # title and content matches
+
+
+def test_search_returns_empty_for_no_match():
+    store = make_store_with_notes()
+    assert store.search("zzznomatch") == []
+
+
+def test_filter_by_tag_returns_matching_notes():
+    store = make_store_with_notes()
+    results = store.filter_by_tag("work")
+    assert all("work" in n.tags for n in results)
+    assert len(results) == 1
+
+
+def test_filter_by_tag_returns_empty_for_missing_tag():
+    store = make_store_with_notes()
+    assert store.filter_by_tag("nonexistent") == []
+
+
+def test_filter_by_date_since():
+    path = tempfile.mktemp(suffix=".json")
+    store = NoteStore(path)
+    old = Note(title="old", content="x", created_at=datetime(2020, 1, 1))
+    new = Note(title="new", content="x", created_at=datetime(2024, 1, 1))
+    store.add(old)
+    store.add(new)
+    results = store.filter_by_date(since=datetime(2023, 1, 1))
+    titles = {n.title for n in results}
+    assert "new" in titles
+    assert "old" not in titles
+
+
+def test_filter_by_date_range():
+    path = tempfile.mktemp(suffix=".json")
+    store = NoteStore(path)
+    for year in [2020, 2022, 2024]:
+        store.add(Note(title=str(year), content="x", created_at=datetime(year, 6, 1)))
+    results = store.filter_by_date(since=datetime(2021, 1, 1), until=datetime(2023, 1, 1))
+    titles = {n.title for n in results}
+    assert "2022" in titles
+    assert "2020" not in titles
+    assert "2024" not in titles

--- a/tests/test_store.py
+++ b/tests/test_store.py
@@ -1,0 +1,60 @@
+import os
+import tempfile
+from notes.model import Note
+from notes.store import NoteStore
+
+
+def make_store():
+    tmp = tempfile.mktemp(suffix=".json")
+    return NoteStore(tmp), tmp
+
+
+def test_add_returns_note():
+    store, _ = make_store()
+    n = store.add(Note(title="Hello", content="World"))
+    assert n.title == "Hello"
+
+
+def test_get_returns_added_note():
+    store, _ = make_store()
+    n = store.add(Note(title="t", content="c"))
+    assert store.get(n.id) == n
+
+
+def test_get_returns_none_for_missing():
+    store, _ = make_store()
+    assert store.get("nonexistent") is None
+
+
+def test_list_returns_all_notes():
+    store, _ = make_store()
+    store.add(Note(title="a", content="1"))
+    store.add(Note(title="b", content="2"))
+    assert len(store.list()) == 2
+
+
+def test_delete_removes_note():
+    store, _ = make_store()
+    n = store.add(Note(title="t", content="c"))
+    assert store.delete(n.id) is True
+    assert store.get(n.id) is None
+
+
+def test_delete_returns_false_for_missing():
+    store, _ = make_store()
+    assert store.delete("nonexistent") is False
+
+
+def test_persistence_across_instances():
+    _, path = make_store()
+    s1 = NoteStore(path)
+    n = s1.add(Note(title="persist", content="me"))
+    s2 = NoteStore(path)
+    assert s2.get(n.id) is not None
+    assert s2.get(n.id).title == "persist"
+
+
+def test_empty_store_on_missing_file():
+    path = tempfile.mktemp(suffix=".json")
+    store = NoteStore(path)
+    assert store.list() == []

--- a/tests/test_tags.py
+++ b/tests/test_tags.py
@@ -1,0 +1,54 @@
+from notes.model import Note
+
+
+def make_note():
+    return Note(title="t", content="c")
+
+
+def test_add_tag():
+    n = make_note()
+    n.add_tag("python")
+    assert "python" in n.tags
+
+
+def test_add_tag_normalises_whitespace_and_case():
+    n = make_note()
+    n.add_tag("  Python  ")
+    assert "python" in n.tags
+
+
+def test_add_tag_is_idempotent():
+    n = make_note()
+    n.add_tag("python")
+    n.add_tag("python")
+    assert n.tags.count("python") == 1
+
+
+def test_remove_tag():
+    n = make_note()
+    n.add_tag("python")
+    n.remove_tag("python")
+    assert "python" not in n.tags
+
+
+def test_remove_tag_noop_if_absent():
+    n = make_note()
+    n.remove_tag("missing")  # should not raise
+
+
+def test_has_tag_true():
+    n = make_note()
+    n.add_tag("python")
+    assert n.has_tag("python") is True
+
+
+def test_has_tag_case_insensitive():
+    n = make_note()
+    n.add_tag("python")
+    assert n.has_tag("Python") is True
+    assert n.has_tag("PYTHON") is True
+
+
+def test_has_tag_false():
+    n = make_note()
+    assert n.has_tag("absent") is False


### PR DESCRIPTION
## Summary

Implements PRD #7: Implement note-taking library

## Issues Implemented

- Closes #1: Add Note model
- Closes #2: Add NoteStore class
- Closes #3: Add search and filter methods to NoteStore
- Closes #4: Add tag management to Note
- Closes #5: Add export to Markdown

## Notes

- #6 (Initial project setup) was already closed — skipped.
- #1 and #2 were executed in parallel (Wave 1).
- #3 and #4 were executed in parallel (Wave 2), both unblocked after Wave 1.
- #5 ran sequentially in Wave 3, after both Wave 2 issues landed.
- All 40 tests passing, no regressions.

---
Orchestrated by Claude via `prd-execute`